### PR TITLE
Fix/signature encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "homepage": "https://github.com/Web3Auth/mpc-core-kit/tree/master#readme",
   "license": "ISC",
   "scripts": {
-    "test": "mocha --config ../../.mocharc.json test/**.ts",
-    "test-debugger": "mocha --config ../../.mocharc.json --inspect-brk test/**.ts",
+    "test": "echo no tests available",
     "dev": "torus-scripts start",
     "build": "torus-scripts build",
     "release": "torus-scripts release",

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -917,7 +917,7 @@ export class Web3AuthMPCCoreKit implements IWeb3Auth {
         signatures: this.signatures,
       });
       await client.cleanup(tss, { signatures: this.signatures, server_coeffs: serverCoeffs });
-      return { v: recoveryParam, r: Buffer.from(r.toString("hex"), "hex"), s: Buffer.from(s.toString("hex"), "hex") };
+      return { v: recoveryParam, r: Buffer.from(r.toString("hex", SCALAR_HEX_LEN), "hex"), s: Buffer.from(s.toString("hex", SCALAR_HEX_LEN), "hex") };
     };
 
     const getPublic: () => Promise<Buffer> = async () => {


### PR DESCRIPTION
Fixes a problem that made some signatures be encoded wrongly (and verification fail). The issue was that padding was not done correctly.

(This is a clone of https://github.com/Web3Auth/mpc-core-kit/pull/24 to merge into master.)