### PR TITLE
fix: delete hashed factorMetadata on reset account

### DIFF
--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -618,7 +618,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     } else {
       await this.tKey.initialize({ neverInitializeNewKey: true });
       const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
-      if (await this.checkIfFactorKeyValid(hashedFactorKey)) {
+      if ((await this.checkIfFactorKeyValid(hashedFactorKey)) && !this.options.disableHashedFactorKey) {
         // Initialize tkey with existing hashed share if available.
         const factorKeyMetadata: ShareStore = await this.getFactorKeyMetadata(hashedFactorKey);
         await this.tKey.inputShareStoreSafe(factorKeyMetadata, true);

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -593,6 +593,9 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       let factorKey: BN;
       if (this.options.disableHashedFactorKey) {
         factorKey = generateFactorKey().private;
+        // delete previous hashed factorKey if present
+        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
+        await this.deleteShareWithFactorKey(hashedFactorKey);
       } else {
         factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
       }
@@ -618,7 +621,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       if (await this.checkIfFactorKeyValid(hashedFactorKey)) {
         // Initialize tkey with existing hashed share if available.
         const factorKeyMetadata: ShareStore = await this.getFactorKeyMetadata(hashedFactorKey);
-        await this.tKey.inputShareStoreSafe(factorKeyMetadata);
+        await this.tKey.inputShareStoreSafe(factorKeyMetadata, true);
         await this.tKey.reconstructKey();
         await this.finalizeTkey(hashedFactorKey);
       }


### PR DESCRIPTION
use update-metadata for inputing factor

- update metadata during hash factor importing.
- add checking to only import if disableHashFactor is false
- delete old hash factor metadata incase the account is reseted and reinitialised with disableHashFactor