### PR TITLE
Fix scalar encoding length

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ export enum TssShareType {
 
 export const VALID_SHARE_INDICES = [TssShareType.DEVICE, TssShareType.RECOVERY];
 
-export const SCALAR_HEX_LEN = 32 * 2; // Length of secp256k1 scalar in hex form.
+export const SCALAR_LEN = 32; // Length of secp256k1 scalar in bytes.
 export const FIELD_ELEMENT_HEX_LEN = 32 * 2; // Length of secp256k1 field element in hex form.
 export const CURVE = new EllipticCurve("secp256k1");
 

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -24,7 +24,7 @@ import {
   FactorKeyTypeShareDescription,
   FIELD_ELEMENT_HEX_LEN,
   MAX_FACTORS,
-  SCALAR_HEX_LEN,
+  SCALAR_LEN,
   SOCIAL_TKEY_INDEX,
   TssShareType,
   VALID_SHARE_INDICES,
@@ -779,7 +779,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     factorEncs[factorPubID] = {
       tssIndex: this.state.tssShareIndex,
       type: "direct",
-      userEnc: await encrypt(Point.fromTkeyPoint(newFactorPub).toBufferSEC1(false), Buffer.from(tssShare.toString(16, SCALAR_HEX_LEN), "hex")),
+      userEnc: await encrypt(Point.fromTkeyPoint(newFactorPub).toBufferSEC1(false), tssShare.toArrayLike(Buffer, "be", SCALAR_LEN)),
       serverEncs: [],
     };
     this.tKey.metadata.addTSSData({
@@ -882,8 +882,8 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
       const participatingServerDKGIndexes = [1, 2, 3];
       const dklsCoeff = tssUtils.getDKLSCoeff(true, participatingServerDKGIndexes, tssShareIndex as number);
-      const denormalisedShare = dklsCoeff.mul(tssShare as BN).umod(CURVE.curve.n);
-      const share = Buffer.from(denormalisedShare.toString(16, SCALAR_HEX_LEN), "hex").toString("base64");
+      const denormalisedShare = dklsCoeff.mul(tssShare).umod(CURVE.curve.n);
+      const share = denormalisedShare.toArrayLike(Buffer, "be", SCALAR_LEN).toString("base64");
 
       if (!currentSession) {
         throw new Error(`sessionAuth does not exist ${currentSession}`);
@@ -916,7 +916,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         signatures: this.signatures,
       });
       await client.cleanup(tss, { signatures: this.signatures, server_coeffs: serverCoeffs });
-      return { v: recoveryParam, r: r.toArrayLike(Buffer, "be", SCALAR_HEX_LEN), s: s.toArrayLike(Buffer, "be", SCALAR_HEX_LEN) };
+      return { v: recoveryParam, r: r.toArrayLike(Buffer, "be", SCALAR_LEN), s: s.toArrayLike(Buffer, "be", SCALAR_LEN) };
     };
 
     const getPublic: () => Promise<Buffer> = async () => {


### PR DESCRIPTION
One of the previous PRs introduced a bug where scalars where encoded to byte buffers with a length that was defined for hex encodings (hence, the buffer was twice the size of what it should be).

This PR corrects that mistake.