### PR TITLE
fix: getWebBrowserFactor can return undefined

### DIFF
--- a/src/helper/browserStorage.ts
+++ b/src/helper/browserStorage.ts
@@ -89,7 +89,7 @@ export async function storeWebBrowserFactor(factorKey: BN, mpcCoreKit: ICoreKit,
   );
 }
 
-export async function getWebBrowserFactor(mpcCoreKit: ICoreKit, storageKey: "local" | "session" = "local"): Promise<string> {
+export async function getWebBrowserFactor(mpcCoreKit: ICoreKit, storageKey: "local" | "session" = "local"): Promise<string | undefined> {
   const metadata = mpcCoreKit.tKey.getMetadata();
   const currentStorage = BrowserStorage.getInstance("mpc_corekit_store", storageKey);
 


### PR DESCRIPTION
 ## What this PR fixes
`getWebBrowserFactor` returns `undefined` if no browser factor is stored for the current user.
This PR adds `undefined` to it's return type.