### PR TITLE
feat: final hash clientId

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -338,6 +338,13 @@ export interface Web3AuthOptions {
    * Recommended for Non Custodial Flow.
    */
   disableHashedFactorKey?: boolean;
+
+  /**
+   * @defaultValue `Web3AuthOptions.web3AuthClientId`
+   * Overwrites the clientId used for hashing the factor key.
+   * Do not use this unless you know what you are doing.
+   */
+  finalHashClientId?: string;
 }
 
 export type Web3AuthOptionsWithDefaults = Required<Web3AuthOptions>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -341,14 +341,14 @@ export interface Web3AuthOptions {
 
   /**
    * @defaultValue `Web3AuthOptions.web3AuthClientId`
-   * Overwrites the clientId used for hashing the factor key.
+   * Overwrites the clientId used as default nonce for hashing the hash factor key.
    *
    * If you want to aggregate the mfa status of client id 1 and client id 2  apps
    * set rootClientId to some common clientID, which can be either client id 1 or client id 2 or any other unique string
    * #PR 72
    * Do not use this unless you know what you are doing.
    */
-  rootClientId?: string;
+  hashedFactorNonce?: string;
 }
 
 export type Web3AuthOptionsWithDefaults = Required<Web3AuthOptions>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -341,10 +341,10 @@ export interface Web3AuthOptions {
 
   /**
    * @defaultValue `Web3AuthOptions.web3AuthClientId`
-   * Overwrites the clientId used as default nonce for hashing the hash factor key.
+   * Overwrites the default value ( clientId ) used as nonce for hashing the hash factor key.
    *
    * If you want to aggregate the mfa status of client id 1 and client id 2  apps
-   * set rootClientId to some common clientID, which can be either client id 1 or client id 2 or any other unique string
+   * set hashedFactorNonce to some common clientID, which can be either client id 1 or client id 2 or any other unique string
    * #PR 72
    * Do not use this unless you know what you are doing.
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -342,9 +342,13 @@ export interface Web3AuthOptions {
   /**
    * @defaultValue `Web3AuthOptions.web3AuthClientId`
    * Overwrites the clientId used for hashing the factor key.
+   *
+   * If you want to aggregate the mfa status of client id 1 and client id 2  apps
+   * set rootClientId to some common clientID, which can be either client id 1 or client id 2 or any other unique string
+   * #PR 72
    * Do not use this unless you know what you are doing.
    */
-  finalHashClientId?: string;
+  rootClientId?: string;
 }
 
 export type Web3AuthOptionsWithDefaults = Required<Web3AuthOptions>;

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -105,7 +105,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     if (!options.redirectPathName) options.redirectPathName = "redirect";
     if (!options.baseUrl) options.baseUrl = `${window.location.origin}/serviceworker`;
     if (!options.disableHashedFactorKey) options.disableHashedFactorKey = false;
-    if (!options.finalHashClientId) options.finalHashClientId = options.web3AuthClientId;
+    if (!options.rootClientId) options.rootClientId = options.web3AuthClientId;
 
     this.options = options as Web3AuthOptionsWithDefaults;
 
@@ -424,7 +424,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   public async enableMFA(enableMFAParams: EnableMFAParams, recoveryFactor = true): Promise<string> {
     this.checkReady();
 
-    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
+    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
     if (!(await this.checkIfFactorKeyValid(hashedFactorKey))) {
       if (this.tKey._localMetadataTransitions[0].length) throw new Error("CommitChanges are required before enabling MFA");
       throw new Error("MFA already enabled");
@@ -635,10 +635,10 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       if (this.options.disableHashedFactorKey) {
         factorKey = generateFactorKey().private;
         // delete previous hashed factorKey if present
-        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
+        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
         await this.deleteMetadataShareBackup(hashedFactorKey);
       } else {
-        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
+        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
       }
       const deviceTSSShare = new BN(generatePrivate());
       const deviceTSSIndex = TssShareType.DEVICE;
@@ -658,7 +658,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       }
     } else {
       await this.tKey.initialize({ neverInitializeNewKey: true });
-      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
+      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
       if ((await this.checkIfFactorKeyValid(hashedFactorKey)) && !this.options.disableHashedFactorKey) {
         // Initialize tkey with existing hashed share if available.
         const factorKeyMetadata: ShareStore = await this.getFactorKeyMetadata(hashedFactorKey);

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -105,7 +105,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     if (!options.redirectPathName) options.redirectPathName = "redirect";
     if (!options.baseUrl) options.baseUrl = `${window.location.origin}/serviceworker`;
     if (!options.disableHashedFactorKey) options.disableHashedFactorKey = false;
-    if (!options.rootClientId) options.rootClientId = options.web3AuthClientId;
+    if (!options.hashedFactorNonce) options.hashedFactorNonce = options.web3AuthClientId;
 
     this.options = options as Web3AuthOptionsWithDefaults;
 
@@ -424,7 +424,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   public async enableMFA(enableMFAParams: EnableMFAParams, recoveryFactor = true): Promise<string> {
     this.checkReady();
 
-    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
+    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.hashedFactorNonce);
     if (!(await this.checkIfFactorKeyValid(hashedFactorKey))) {
       if (this.tKey._localMetadataTransitions[0].length) throw new Error("CommitChanges are required before enabling MFA");
       throw new Error("MFA already enabled");
@@ -635,10 +635,10 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       if (this.options.disableHashedFactorKey) {
         factorKey = generateFactorKey().private;
         // delete previous hashed factorKey if present
-        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
+        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.hashedFactorNonce);
         await this.deleteMetadataShareBackup(hashedFactorKey);
       } else {
-        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
+        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.hashedFactorNonce);
       }
       const deviceTSSShare = new BN(generatePrivate());
       const deviceTSSIndex = TssShareType.DEVICE;
@@ -658,7 +658,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       }
     } else {
       await this.tKey.initialize({ neverInitializeNewKey: true });
-      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.rootClientId);
+      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.hashedFactorNonce);
       if ((await this.checkIfFactorKeyValid(hashedFactorKey)) && !this.options.disableHashedFactorKey) {
         // Initialize tkey with existing hashed share if available.
         const factorKeyMetadata: ShareStore = await this.getFactorKeyMetadata(hashedFactorKey);

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -105,6 +105,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     if (!options.redirectPathName) options.redirectPathName = "redirect";
     if (!options.baseUrl) options.baseUrl = `${window.location.origin}/serviceworker`;
     if (!options.disableHashedFactorKey) options.disableHashedFactorKey = false;
+    if (!options.finalHashClientId) options.finalHashClientId = options.web3AuthClientId;
 
     this.options = options as Web3AuthOptionsWithDefaults;
 
@@ -423,7 +424,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   public async enableMFA(enableMFAParams: EnableMFAParams, recoveryFactor = true): Promise<string> {
     this.checkReady();
 
-    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
+    const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
     if (!(await this.checkIfFactorKeyValid(hashedFactorKey))) {
       if (this.tKey._localMetadataTransitions[0].length) throw new Error("CommitChanges are required before enabling MFA");
       throw new Error("MFA already enabled");
@@ -634,10 +635,10 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       if (this.options.disableHashedFactorKey) {
         factorKey = generateFactorKey().private;
         // delete previous hashed factorKey if present
-        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
+        const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
         await this.deleteMetadataShareBackup(hashedFactorKey);
       } else {
-        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
+        factorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
       }
       const deviceTSSShare = new BN(generatePrivate());
       const deviceTSSIndex = TssShareType.DEVICE;
@@ -657,7 +658,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       }
     } else {
       await this.tKey.initialize({ neverInitializeNewKey: true });
-      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.web3AuthClientId);
+      const hashedFactorKey = getHashedPrivateKey(this.state.oAuthKey, this.options.finalHashClientId);
       if ((await this.checkIfFactorKeyValid(hashedFactorKey)) && !this.options.disableHashedFactorKey) {
         // Initialize tkey with existing hashed share if available.
         const factorKeyMetadata: ShareStore = await this.getFactorKeyMetadata(hashedFactorKey);


### PR DESCRIPTION
Some company have different services with respective clientId to track activity but uses the same verifier and verifierId.
Having different clientId will cause different Hash Factor for the same account.
adding override feature with finalHashClientId to have consistent hash