### PR TITLE
[IRT-996] Add CI and override @toruslabs/http-helpers to 6.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+on: push
+
+name: tests
+
+jobs:
+  test:
+    name: run tests
+    strategy:
+      matrix:
+        node: ["20.x"]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+       - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-       - name: Set up node
+      - name: Set up node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3394,7 +3394,8 @@
     },
     "node_modules/@tkey-mpc/core/node_modules/@toruslabs/http-helpers": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-5.0.0.tgz",
+      "integrity": "sha512-GmezWz9JeF6YyhjLSm+9XDF4YaeICEckY0Jbo43i86SjhfJYgRWqEi63VSiNsaqc/z810Q0FQvEk1TnBRX2tgA==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -3655,8 +3656,9 @@
       }
     },
     "node_modules/@tkey-mpc/storage-layer-torus/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -3754,8 +3756,9 @@
       }
     },
     "node_modules/@toruslabs/base-session-manager/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -3938,8 +3941,9 @@
       }
     },
     "node_modules/@toruslabs/customauth/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -4018,8 +4022,9 @@
       }
     },
     "node_modules/@toruslabs/fetch-node-details/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -4136,9 +4141,9 @@
       }
     },
     "node_modules/@toruslabs/metadata-helpers/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-5.0.0.tgz",
-      "integrity": "sha512-GmezWz9JeF6YyhjLSm+9XDF4YaeICEckY0Jbo43i86SjhfJYgRWqEi63VSiNsaqc/z810Q0FQvEk1TnBRX2tgA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -4296,6 +4301,28 @@
         "elliptic": "^6.5.4"
       }
     },
+    "node_modules/@toruslabs/rss-client/node_modules/@toruslabs/http-helpers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "loglevel": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.x",
+        "@sentry/types": "^7.x"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@toruslabs/rss-client/node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
@@ -4438,8 +4465,9 @@
       }
     },
     "node_modules/@toruslabs/torus.js/node_modules/@toruslabs/http-helpers": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-6.0.0.tgz",
+      "integrity": "sha512-/KrISB9fGV2TM+5Z+0CGj24d/G08kqbB+kodO3nbwNcS0a55dpy+RiB0naF3H1gbEt4Ah5YH8qCDyAZ+zcR2FQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,17 @@
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"
   },
+  "overrides": {
+    "@tkey-mpc/storage-layer-torus": {
+      "@toruslabs/http-helpers": "^6.0.0"
+    },
+    "@toruslabs/base-session-manager": {
+      "@toruslabs/http-helpers": "^6.0.0"
+    },
+    "@toruslabs/customauth": {
+      "@toruslabs/http-helpers": "^6.0.0"
+    }
+  },
   "lint-staged": {
     "!(*d).ts": [
       "eslint --cache --fix",

--- a/tests/factors.spec.ts
+++ b/tests/factors.spec.ts
@@ -128,7 +128,7 @@ const variable: FactorTestVariable[] = [
   { types: TssShareType.RECOVERY, manualSync: true, asyncStorage: new AsyncMemoryStorage() },
 ];
 
-const email = "testmail99";
+const email = "testmail102";
 variable.forEach(async (testVariable) => {
   const newCoreKitLogInInstance = async () => {
     const instance = new Web3AuthMPCCoreKit({


### PR DESCRIPTION
## Description
- Add test CI and override @toruslabs/http-helpers from 5.0.0 to 6.0.0 for a few selected libraries which fixes a timeout issue that causes tests to hang for 10 minutes