### PR TITLE
fix: tests

### DIFF
--- a/tests/securityQuestion.spec.ts
+++ b/tests/securityQuestion.spec.ts
@@ -30,7 +30,7 @@ export const TssSecurityQuestionsTest = async (newInstance: () => Promise<Web3Au
   test(`#Tss Security Question - ${testVariable.manualSync} `, async function (t) {
     await t.before(async function () {
       const coreKitInstance = await newInstance();
-      if (coreKitInstance.status === COREKIT_STATUS.REQUIRED_SHARE) await criticalResetAccount(coreKitInstance);
+      await criticalResetAccount(coreKitInstance);
       await coreKitInstance.logout();
       BrowserStorage.getInstance("corekit_store", testVariable.storage).resetStore();
     });


### PR DESCRIPTION
reset account before test start
(sfa) is enabled by default now