### PR TITLE
fix share derivation

### DIFF
--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -660,7 +660,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
     if (!this.state.factorKey) throw new Error("factorKey not present");
     const { tssShare } = await this.tKey.getTSSShare(this.state.factorKey, {
-      accountIndex: this.state.accountIndex,
+      accountIndex: 0,
     });
     const tssNonce = this.getTssNonce();
 
@@ -706,7 +706,9 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
     const dklsCoeff = getDKLSCoeff(true, participatingServerDKGIndexes, tssShareIndex as number);
     const denormalisedShare = dklsCoeff.mul(tssShare).umod(CURVE.curve.n);
-    const share = scalarBNToBufferSEC1(denormalisedShare).toString("base64");
+    const accountNonce = this.tkey.computeAccountNonce(this.state.accountIndex);
+    const derivedShare = denormalisedShare.add(accountNonce).umod(CURVE.curve.n);
+    const share = scalarBNToBufferSEC1(derivedShare).toString("base64");
 
     if (!currentSession) {
       throw new Error(`sessionAuth does not exist ${currentSession}`);


### PR DESCRIPTION
Fix mulitwallet signing issue with tss share index 3
Issue:
muilt-wallet signing (wallet index > 0) failed when user login with recovery tssShare (tssIndex 3)

root Cause: 
The computed nonce should be added after the share denormalized( calculate with langrange coeff ) instead of before.

Fix:
add nonce after share is denormailzed
