### PR TITLE
add use client generated key params

### DIFF
--- a/src/helper/errors.ts
+++ b/src/helper/errors.ts
@@ -134,6 +134,7 @@ class CoreKitError extends AbstractCoreKitError {
     1004: "OAuth login is NOT supported in this UX mode.",
     1005: "No valid storage option found.",
     1006: "No data found in storage.",
+    1007: "Invalid config.",
 
     // TSS and key management errors
     1101: "'tssLib' is required when running in this UX mode.",
@@ -208,6 +209,10 @@ class CoreKitError extends AbstractCoreKitError {
 
   public static noDataFoundInStorage(extraMessage = ""): ICoreKitError {
     return CoreKitError.fromCode(1006, extraMessage);
+  }
+
+  public static invalidConfig(extraMessage = ""): ICoreKitError {
+    return CoreKitError.fromCode(1007, extraMessage);
   }
 
   // TSS and key management errors

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -412,9 +412,20 @@ export interface Web3AuthOptions {
   /**
    * Set this flag to false to generate keys on client side
    * by default keys are generated on using dkg protocol on a distributed network
-   * @defaultValue false if keyType is ed25519, true for secp256k1 keys
+   * Note: This option is not supported for ed25519 key type
+   * @defaultValue `true`
    */
   useDKG?: boolean;
+
+  /**
+   * @defaultValue `false` for secp256k1 and `true` for ed25519
+   * Set this flag to true to use the client generated key for signing
+   * Note: This option is set to true for ed25519 key type by default to ensure ed25519 mpc key  seed exportablity.
+   * The seed thn can be used for importing user's key other wallets like phantom etc
+   * If you set this flag to false for ed25519 key type, you will not be able to export the seed and
+   * only scalar will be exported, scalar can be used for signing outside of this sdk but not for importing the key in other wallets.
+   */
+  useClientGeneratedKey?: boolean;
 }
 
 export type Web3AuthOptionsWithDefaults = Required<Web3AuthOptions>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -422,10 +422,10 @@ export interface Web3AuthOptions {
    * Set this flag to true to use the client generated key for signing
    * Note: This option is set to true for ed25519 key type by default to ensure ed25519 mpc key  seed exportablity.
    * The seed thn can be used for importing user's key other wallets like phantom etc
-   * If you set this flag to false for ed25519 key type, you will not be able to export the seed and
+   * If you set this flag to false for ed25519 key type, you will not be able to export the seed for ed25519 keys and
    * only scalar will be exported, scalar can be used for signing outside of this sdk but not for importing the key in other wallets.
    */
-  useClientGeneratedKey?: boolean;
+  useClientGeneratedTSSKey?: boolean;
 }
 
 export type Web3AuthOptionsWithDefaults = Required<Web3AuthOptions>;

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -201,10 +201,6 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     return this.options.uxMode === UX_MODE.REDIRECT;
   }
 
-  private get useDKG(): boolean {
-    return this.keyType === KeyType.ed25519 && this.options.useDKG === undefined ? false : this.options.useDKG;
-  }
-
   private get useClientGeneratedKey(): boolean {
     return this.keyType === KeyType.ed25519 && this.options.useDKG === undefined ? true : !!this.options.useDKG;
   }
@@ -249,7 +245,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       throw CoreKitError.nodeDetailsRetrievalFailed();
     }
 
-    if (this.keyType === KEY_TYPE.ED25519 && this.useDKG !== undefined) {
+    if (this.keyType === KEY_TYPE.ED25519 && this.options.useDKG !== undefined) {
       throw CoreKitError.invalidConfig("DKG is not supported for ed25519 key type");
     }
 
@@ -263,7 +259,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         locationReplaceOnRedirect: true,
         serverTimeOffset: this.options.serverTimeOffset,
         keyType: this.keyType,
-        useDkg: this.useDKG,
+        useDkg: this.options.useDKG,
       },
     });
 

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -201,8 +201,8 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     return this.options.uxMode === UX_MODE.REDIRECT;
   }
 
-  private get useClientGeneratedKey(): boolean {
-    return this.keyType === KeyType.ed25519 && this.options.useDKG === undefined ? true : !!this.options.useDKG;
+  private get useClientGeneratedTSSKey(): boolean {
+    return this.keyType === KeyType.ed25519 && this.options.useClientGeneratedTSSKey === undefined ? true : !!this.options.useClientGeneratedTSSKey;
   }
 
   // RecoverTssKey only valid for user that enable MFA where user has 2 type shares :
@@ -891,7 +891,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     const existingUser = await this.isMetadataPresent(this.state.postBoxKey);
     let importTssKey = providedImportTssKey;
     if (!existingUser) {
-      if (!importTssKey && this.useClientGeneratedKey) {
+      if (!importTssKey && this.useClientGeneratedTSSKey) {
         if (this.keyType === KeyType.ed25519) {
           const k = generateEd25519Seed();
           importTssKey = k.toString("hex");


### PR DESCRIPTION
- Seperate out useDKG flag from client side mpc key flag.

It ensures that useDKG is only used for secp keys and throws errors for ed25519.

A new param  `useClientGeneratedKey` added to allow generating mpc keys on client side.


useClientGeneratedKey is true for ed25519 and false for secp256k1 keys by default.