### PR TITLE
import sfa key

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -85,7 +85,18 @@ export type MPCKeyDetails = {
   tssPubKey?: TkeyPoint;
 };
 
-export type OAuthLoginParams = (SubVerifierDetailsParams | AggregateVerifierLoginParams) & { importTssKey?: string };
+export type OAuthLoginParams = (SubVerifierDetailsParams | AggregateVerifierLoginParams) & {
+  /**
+   * Key to import key into Tss during first time login.
+   */
+  importTssKey?: string;
+
+  /**
+   * For new users, use SFA key if user was registered with SFA before.
+   * Useful when you created the user with SFA before and now want to convert it to TSS.
+   */
+  registerExistingSFAKey?: boolean;
+};
 export type UserInfo = TorusVerifierResponse & LoginWindowResponse;
 
 export interface EnableMFAParams {
@@ -145,6 +156,12 @@ export interface JWTLoginParams {
    * Key to import key into Tss during first time login.
    */
   importTssKey?: string;
+
+  /**
+   * For new users, use SFA key if user was registered with SFA before.
+   * Useful when you created the user with SFA before and now want to convert it to TSS.
+   */
+  registerExistingSFAKey?: boolean;
 
   /**
    * Number of TSS public keys to prefetch. For the best performance, set it to

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1026,13 +1026,13 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         }
       }
       await this.handleNewUser(importTssKey);
-      if (importTssKey) {
-        throw CoreKitError.tssKeyImportNotAllowed();
-      }
-    } else {
       if (importTssKey && isSfaKey) {
         await this.tkey.addLocalMetadataTransitions({ input: [{ message: ONE_KEY_DELETE_NONCE }], privKey: [new BN(this.state.postBoxKey, "hex")] });
         if (!this.tkey?.manualSync) await this.tkey?.syncLocalMetadataTransitions();
+      }
+    } else {
+      if (importTssKey) {
+        throw CoreKitError.tssKeyImportNotAllowed();
       }
       await this.handleExistingUser();
     }

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1013,39 +1013,36 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   }
 
   private async setupTkey(
-    providedImportTssKey?: string,
+    providedImportKey?: string,
     sfaLoginResponse?: TorusKey | TorusLoginResponse | TorusAggregateLoginResponse,
-    registerSFAKey?: boolean
+    importingSFAKey?: boolean
   ): Promise<void> {
-    if (registerSFAKey && !sfaLoginResponse) {
+    if (importingSFAKey && !sfaLoginResponse) {
       throw CoreKitError.default("SFA key registration requires SFA login response");
-    }
-    if (providedImportTssKey && registerSFAKey) {
-      throw CoreKitError.default("Cannot provide both importTssKey and registerSFAKey");
     }
     if (!this.state.postBoxKey) {
       throw CoreKitError.userNotLoggedIn();
     }
     const existingUser = await this.isMetadataPresent(this.state.postBoxKey);
-    let importTssKey = providedImportTssKey;
+    let importKey = providedImportKey;
     if (!existingUser) {
-      if (!importTssKey && this.useClientGeneratedTSSKey) {
+      if (!importKey && this.useClientGeneratedTSSKey) {
         if (this.keyType === KeyType.ed25519) {
           const k = generateEd25519Seed();
-          importTssKey = k.toString("hex");
+          importKey = k.toString("hex");
         } else if (this.keyType === KeyType.secp256k1) {
           const k = secp256k1.genKeyPair().getPrivate();
-          importTssKey = scalarBNToBufferSEC1(k).toString("hex");
+          importKey = scalarBNToBufferSEC1(k).toString("hex");
         } else {
           throw CoreKitError.default("Unsupported key type");
         }
       }
-      if (registerSFAKey && sfaLoginResponse && sfaLoginResponse.metadata.upgraded) {
+      if (importingSFAKey && sfaLoginResponse && sfaLoginResponse.metadata.upgraded) {
         throw CoreKitError.default("SFA key registration is not allowed for already upgraded users");
       }
-      await this.handleNewUser(importTssKey, registerSFAKey);
+      await this.handleNewUser(importKey, importingSFAKey);
     } else {
-      if (importTssKey) {
+      if (importKey) {
         throw CoreKitError.tssKeyImportNotAllowed();
       }
       await this.handleExistingUser();

--- a/tests/importRecovery.spec.ts
+++ b/tests/importRecovery.spec.ts
@@ -4,14 +4,14 @@ import test from "node:test";
 import { tssLib as tssLibDKLS } from "@toruslabs/tss-dkls-lib";
 import { tssLib as tssLibFROST } from "@toruslabs/tss-frost-lib";
 
-import { AsyncStorage, MemoryStorage, TssLib, TssShareType, WEB3AUTH_NETWORK } from "../src";
+import { AsyncStorage, MemoryStorage, TssLibType, TssShareType, WEB3AUTH_NETWORK } from "../src";
 import { bufferToElliptic, criticalResetAccount, newCoreKitLogInInstance } from "./setup";
 
 type ImportKeyTestVariable = {
   manualSync?: boolean;
   email: string;
   importKeyEmail: string;
-  tssLib: TssLib;
+  tssLib: TssLibType;
 };
 
 const storageInstance = new MemoryStorage();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -153,13 +153,13 @@ export const loginWithSFA = async ({
   const { idToken, parsedToken } = login ? await login(email) : await mockLogin(email);
   await instance.init();
   const nodeDetails = await instance.torusSp.customAuthInstance.nodeDetailManager.getNodeDetails({
-    verifier: "torus-key-test",
+    verifier: "torus-test-health",
     verifierId: parsedToken.email,
   })
   return await instance.torusSp.customAuthInstance.torus.retrieveShares({
     idToken,
     nodePubkeys: nodeDetails.torusNodePub,
-    verifier: "torus-key-test",
+    verifier: "torus-test-health",
     verifierParams: {
       verifier_id: parsedToken.email,
     },

--- a/tests/sfaImport.spec.ts
+++ b/tests/sfaImport.spec.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert";
+import test from "node:test";
+
+import { tssLib as tssLibDKLS } from "@toruslabs/tss-dkls-lib";
+import { tssLib as tssLibFROST } from "@toruslabs/tss-frost-lib";
+
+import { AsyncStorage, MemoryStorage, TssLibType, TssShareType, WEB3AUTH_NETWORK } from "../src";
+import { criticalResetAccount, generateRandomEmail, loginWithSFA, newCoreKitLogInInstance } from "./setup";
+
+type ImportKeyTestVariable = {
+  manualSync?: boolean;
+  email: string;
+  tssLib: TssLibType;
+};
+
+const storageInstance = new MemoryStorage();
+export const ImportSFATest = async (testVariable: ImportKeyTestVariable) => {
+  async function newCoreKitInstance(email: string) {
+    return newCoreKitLogInInstance({
+      network: WEB3AUTH_NETWORK.DEVNET,
+      manualSync: testVariable.manualSync,
+      email: email,
+      storageInstance,
+      tssLib: testVariable.tssLib,
+      registerExistingSFAKey: true,
+    });
+  }
+
+  async function resetAccount(email: string) {
+    const kit = await newCoreKitInstance(email);
+    await criticalResetAccount(kit);
+    await kit.logout();
+    await new AsyncStorage(kit._storageKey, storageInstance).resetStore();
+  }
+
+  test(`import sfa key and recover tss key : ${testVariable.manualSync}`, async function (t) {
+    const beforeTest = async () => {
+      await resetAccount(testVariable.email);
+    };
+
+    await beforeTest();
+
+      await t.test("#recover Tss key using 2 factors key, import tss key to new oauth login", async function () {
+      const sfaResult = await loginWithSFA({
+        network: WEB3AUTH_NETWORK.DEVNET,
+        manualSync: testVariable.manualSync,
+        email: testVariable.email,
+        storageInstance,
+      });
+      const coreKitInstance = await newCoreKitInstance(testVariable.email);
+
+      // Create 2 factors which will be used to recover tss key.
+      const factorKeyDevice = await coreKitInstance.createFactor({
+        shareType: TssShareType.DEVICE,
+      });
+
+      const factorKeyRecovery = await coreKitInstance.createFactor({
+        shareType: TssShareType.RECOVERY,
+      });
+
+      if (testVariable.manualSync) {
+        await coreKitInstance.commitChanges();
+      }
+
+      // Export key and logout.
+      const exportedTssKey1 = await coreKitInstance._UNSAFE_exportTssKey();
+      await coreKitInstance.logout();
+
+      // Recover key from any two factors.
+      const recoveredTssKey = await coreKitInstance._UNSAFE_recoverTssKey([factorKeyDevice, factorKeyRecovery]);
+      assert.strictEqual(recoveredTssKey, exportedTssKey1);
+      assert.strictEqual(sfaResult.finalKeyData.privKey,recoveredTssKey);
+    // sfa key should be empty after import to mpc
+    const sfaResult2 = await loginWithSFA({
+      network: WEB3AUTH_NETWORK.DEVNET,
+      manualSync: testVariable.manualSync,
+      email: testVariable.email,
+      storageInstance,
+    });
+    assert.strictEqual(sfaResult2.finalKeyData.privKey,"");
+
+    });
+
+    t.afterEach(function () {
+      return console.info("finished running recovery test");
+    });
+    t.after(function () {
+      return console.info("finished running recovery tests");
+    });
+  });
+};
+
+const variable: ImportKeyTestVariable[] = [
+  { manualSync: false, email: generateRandomEmail(), tssLib: tssLibDKLS },
+  { manualSync: true, email: generateRandomEmail(), tssLib: tssLibDKLS },
+  { manualSync: false, email: generateRandomEmail(), tssLib: tssLibFROST },
+];
+
+variable.forEach(async (testVariable) => {
+  await ImportSFATest(testVariable);
+});

--- a/tests/sfaImport.spec.ts
+++ b/tests/sfaImport.spec.ts
@@ -34,13 +34,10 @@ export const ImportSFATest = async (testVariable: ImportKeyTestVariable) => {
   }
 
   test(`import sfa key and recover tss key : ${testVariable.manualSync}`, async function (t) {
-    const beforeTest = async () => {
-      await resetAccount(testVariable.email);
-    };
-
-    await beforeTest();
-
-      await t.test("#recover Tss key using 2 factors key, import tss key to new oauth login", async function () {
+    const afterTest = async () => {
+        await resetAccount(testVariable.email);
+      };
+    await t.test("#recover Tss key using 2 factors key, import tss key to new oauth login", async function () {
       const sfaResult = await loginWithSFA({
         network: WEB3AUTH_NETWORK.DEVNET,
         manualSync: testVariable.manualSync,
@@ -81,6 +78,7 @@ export const ImportSFATest = async (testVariable: ImportKeyTestVariable) => {
 
     });
 
+    await afterTest();
     t.afterEach(function () {
       return console.info("finished running recovery test");
     });

--- a/tests/sfaImport.spec.ts
+++ b/tests/sfaImport.spec.ts
@@ -74,7 +74,14 @@ export const ImportSFATest = async (testVariable: ImportKeyTestVariable) => {
       email: testVariable.email,
       storageInstance,
     });
-    assert.strictEqual(sfaResult2.finalKeyData.privKey,"");
+    assert.strictEqual(sfaResult2.finalKeyData.privKey, "");
+        
+    const coreKitInstance2 = await newCoreKitInstance(testVariable.email);
+    const tssKey2 = await coreKitInstance2._UNSAFE_exportTssKey();
+    // core kit should have same sfa key which was imported before
+    assert.strictEqual(tssKey2, exportedTssKey1);
+    assert.strictEqual(sfaResult.finalKeyData.privKey, tssKey2);
+
 
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
This pr allows users to import existing sfa users to mfa.

<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:


## Description
This PR adds a new parameter named `registerExistingSFAKey` in login function. If this param is set to true thn it sfa key will be imported to mpc.

Few things to consider:-
- Once sfa key is imported, key wont be accesible from sfa sdks.

- Also this function will throw error if sfa key was generated for v1 sfa user. Upgrading for v1 users is not possible at all so we should mention this in docs such that application can handle this case while registering sfa user.

- This doesn't work for redirect flow, there is a bug in mpc core kit which doesn't handles redirect import case, so i have added it to throw an error if import key flow is used in redirect mode. We will remove the error once the redirect flow is fixed. 




## How has this been tested?
I have added one new test which creates a SFA key, than sets `registerExistingSFAKey` in mpc core kit so that mpc core kit import sfa key.
Later test tries to login with sfa again and sfa key should be empty, where as mpc exported key should match existing sfa key.


<!--- Include details of your testing environment, tests ran to see how -->

<!--- your change affects other areas of the code, etc. -->
This PR affects, loginWithJwt, loginWithOauth and setupTkey functions

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (run lint)
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My code requires a db migration.
