### PR TITLE
fix: check for invalid factor key during inputfactor

### DIFF
--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -512,6 +512,12 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       // input tkey device share when required share > 0 ( or not reconstructed )
       // assumption tkey shares will not changed
       if (!this.tKey.secp256k1Key) {
+        const factorKeyPrivate = factorKeyCurve.keyFromPrivate(factorKey.toBuffer());
+        const factorPubX = factorKeyPrivate.getPublic().getX().toString("hex").padStart(64, "0");
+        const factorEncExist = this.tkey.metadata.factorEncs?.[this.tkey.tssTag]?.[factorPubX];
+        if (!factorEncExist) {
+          throw CoreKitError.providedFactorKeyInvalid("Invalid FactorKey provided. Failed to input factor key.");
+        }
         const factorKeyMetadata = await this.getFactorKeyMetadata(factorKey);
         await this.tKey.inputShareStoreSafe(factorKeyMetadata, true);
       }

--- a/tests/factors.spec.ts
+++ b/tests/factors.spec.ts
@@ -158,6 +158,8 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
 
       const browserFactor = await instance2.getDeviceFactor();
 
+      const factorBN = new BN(recoverFactor, "hex")
+
       // login with mfa factor
       await instance2.inputFactorKey(new BN(recoverFactor, "hex"));
       assert.strictEqual(instance2.status, COREKIT_STATUS.LOGGED_IN);
@@ -166,6 +168,15 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
       // new instance
       const instance3 = await newInstance();
       assert.strictEqual(instance3.status, COREKIT_STATUS.REQUIRED_SHARE);
+
+
+
+      try {
+        await instance3.inputFactorKey(factorBN.subn(1));
+        throw Error("should not be able to input factor");
+      } catch (e) {
+        assert(e instanceof Error);
+      }
 
       await instance3.inputFactorKey(new BN(browserFactor, "hex"));
       assert.strictEqual(instance3.status, COREKIT_STATUS.LOGGED_IN);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:

Currently we depend on ability of factor to retrieve shareStore to reject or accept the factor.
Adding this logic checking availability of factorPub against the metadata 

## Description
<!--- Describe your changes in detail -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
