### PR TITLE
Fix/disable hashed factorkey

### DIFF
--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1225,7 +1225,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         }
       }
     } catch (err) {
-      log.warn("failed to authorize session please use new", err);
+      log.warn("failed to authorize session please use new instance without rehydration", err);
     }
   }
 

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -323,6 +323,11 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     if (this.isNodejsOrRN(this.options.uxMode)) {
       throw CoreKitError.oauthLoginUnsupported(`Oauth login is NOT supported in ${this.options.uxMode} mode.`);
     }
+
+    if ( this.state.factorKey ) {
+      throw CoreKitError.oauthLoginUnsupported("Instance is alreay login or rehydrated");
+    }
+
     const { importTssKey, registerExistingSFAKey } = params;
     const tkeyServiceProvider = this.torusSp;
 
@@ -677,7 +682,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
    */
   public getPubKey(): Buffer {
     const { tssPubKey } = this.state;
-    return Buffer.from(tssPubKey);
+    return tssPubKey;
   }
 
   /**
@@ -1107,6 +1112,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
           shareDescription: FactorKeyTypeShareDescription.Other,
           updateMetadata: false,
         });
+        await this.setDeviceFactor(factorKey);
       } else {
         await this.addFactorDescription({
           factorKey,
@@ -1199,6 +1205,14 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         signatures: result.signatures,
         userInfo: result.userInfo,
       });
+
+      // update device factor if not present upon rehydration
+      if (this.options.disableHashedFactorKey) {
+        const deviceFactorKey = await this.getDeviceFactor();
+        if (!deviceFactorKey && this.state.factorKey && this.state.tssShareIndex === TssShareType.DEVICE) {
+          await this.setDeviceFactor(this.state.factorKey);
+        }
+      }
     } catch (err) {
       log.warn("failed to authorize session", err);
     }

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -682,7 +682,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
    */
   public getPubKey(): Buffer {
     const { tssPubKey } = this.state;
-    return tssPubKey;
+    return Buffer.from(tssPubKey);
   }
 
   /**
@@ -761,7 +761,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     }
 
     // Client lib expects pub key in XY-format, base64-encoded.
-    const tssPubKeyBase64 = tssPubKey.toSEC1(secp256k1).subarray(1).toString("base64");
+    const tssPubKeyBase64 = Buffer.from(tssPubKey.toSEC1(secp256k1).subarray(1)).toString("base64");
 
     const client = new Client(
       currentSession,
@@ -801,7 +801,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     this.wasmLib = await this.loadTssWasm();
     if (this.keyType === KeyType.secp256k1) {
       const sig = await this.sign_ECDSA_secp256k1(data, hashed, secp256k1Precompute);
-      return Buffer.concat([new Uint8Array(sig.r), new Uint8Array(sig.s), new Uint8Array([sig.v])]);
+      return Buffer.concat([sig.r, sig.s, Buffer.from([sig.v])]);
     } else if (this.keyType === KeyType.ed25519) {
       return this.sign_ed25519(data, hashed);
     }
@@ -898,7 +898,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       await this.tKey._syncShareMetadata();
       await this.tKey.syncLocalMetadataTransitions();
 
-      if (this.sessionId) {
+      if (this.sessionManager && this.sessionId) {
         const payload: SessionData = {
           postBoxKey: this.state.postBoxKey,
           postboxKeyNodeIndexes: this.state.postboxKeyNodeIndexes || [],
@@ -1257,7 +1257,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         postboxKeyNodeIndexes: postboxKeyNodeIndexes || [],
         factorKey: factorKey?.toString("hex"),
         tssShareIndex: tssShareIndex as number,
-        tssPubKey: tssPubKey.toString("hex"),
+        tssPubKey: Buffer.from(tssPubKey).toString("hex"),
         signatures: this.signatures,
         userInfo,
       };
@@ -1534,7 +1534,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       clientXCoord,
       clientShareAdjustedHex,
       pubKeyHex,
-      new Uint8Array(data),
+      data,
       serverCoefficientsHex,
       this.socketTransports
     );

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -897,6 +897,19 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       // manual call syncLocalMetadataTransitions() required to sync local transitions to storage
       await this.tKey._syncShareMetadata();
       await this.tKey.syncLocalMetadataTransitions();
+
+      if (this.sessionId) {
+        const payload: SessionData = {
+          postBoxKey: this.state.postBoxKey,
+          postboxKeyNodeIndexes: this.state.postboxKeyNodeIndexes || [],
+          factorKey: this.state.factorKey?.toString("hex"),
+          tssShareIndex: this.state.tssShareIndex as number,
+          tssPubKey: this.state.tssPubKey?.toString("hex"),
+          signatures: this.signatures,
+          userInfo: this.state.userInfo,
+        };
+        this.sessionManager.updateSession(payload);
+      }
     } catch (error: unknown) {
       log.error("sync metadata error", error);
       throw error;
@@ -1214,7 +1227,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         }
       }
     } catch (err) {
-      log.warn("failed to authorize session", err);
+      log.warn("failed to authorize session please use new", err);
     }
   }
 

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1,4 +1,14 @@
-import { BNString, KeyType, ONE_KEY_DELETE_NONCE, Point, secp256k1, SHARE_DELETED, ShareStore, StringifiedType } from "@tkey/common-types";
+import {
+  BNString,
+  KEY_NOT_FOUND,
+  KeyType,
+  ONE_KEY_DELETE_NONCE,
+  Point,
+  secp256k1,
+  SHARE_DELETED,
+  ShareStore,
+  StringifiedType,
+} from "@tkey/common-types";
 import { CoreError } from "@tkey/core";
 import { ShareSerializationModule } from "@tkey/share-serialization";
 import { TorusStorageLayer } from "@tkey/storage-layer-torus";
@@ -612,7 +622,6 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
       const hashedFactorPub = getPubKeyPoint(hashedFactorKey, factorKeyCurve);
       await this.deleteFactor(hashedFactorPub, hashedFactorKey);
-      await this.deleteMetadataShareBackup(hashedFactorKey);
 
       // only recovery factor = true
       let backupFactorKey;
@@ -1169,7 +1178,6 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
     this.updateState({ tssShareIndex, tssPubKey, factorKey });
 
-
     if (this.sessionManager && this.sessionId) {
       const payload: SessionData = {
         postBoxKey: this.state.postBoxKey,
@@ -1184,7 +1192,6 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     } else {
       await this.createSession();
     }
-
   }
 
   private checkReady() {
@@ -1294,7 +1301,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   private async getFactorKeyMetadata(factorKey: BN): Promise<ShareStore> {
     this.checkReady();
     const factorKeyMetadata = await this.tKey?.readMetadata<StringifiedType>(factorKey);
-    if (!factorKeyMetadata || factorKeyMetadata.message === "KEY_NOT_FOUND") {
+    if (!factorKeyMetadata || factorKeyMetadata.message === KEY_NOT_FOUND || factorKeyMetadata.message === SHARE_DELETED) {
       throw CoreKitError.noMetadataFound();
     }
     return ShareStore.fromJSON(factorKeyMetadata);

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -335,7 +335,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     }
 
     if (this.state.factorKey) {
-      throw CoreKitError.oauthLoginUnsupported("Instance is alreay login or rehydrated");
+      throw CoreKitError.oauthLoginUnsupported("Instance is already logged in or rehydrated");
     }
 
     const { importTssKey, registerExistingSFAKey } = params;
@@ -404,6 +404,11 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
   public async loginWithJWT(params: JWTLoginParams): Promise<void> {
     this.checkReady();
+
+    if (this.state.factorKey) {
+      throw CoreKitError.oauthLoginUnsupported("Instance is already logged in or rehydrated");
+    }
+
     const { prefetchTssPublicKeys = 1 } = params;
     if (prefetchTssPublicKeys > 3) {
       throw CoreKitError.prefetchValueExceeded(`The prefetch value '${prefetchTssPublicKeys}' exceeds the maximum allowed limit of 3.`);

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -324,7 +324,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       throw CoreKitError.oauthLoginUnsupported(`Oauth login is NOT supported in ${this.options.uxMode} mode.`);
     }
 
-    if ( this.state.factorKey ) {
+    if (this.state.factorKey) {
       throw CoreKitError.oauthLoginUnsupported("Instance is alreay login or rehydrated");
     }
 
@@ -761,7 +761,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     }
 
     // Client lib expects pub key in XY-format, base64-encoded.
-    const tssPubKeyBase64 = Buffer.from(tssPubKey.toSEC1(secp256k1).subarray(1)).toString("base64");
+    const tssPubKeyBase64 = tssPubKey.toSEC1(secp256k1).subarray(1).toString("base64");
 
     const client = new Client(
       currentSession,
@@ -801,7 +801,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
     this.wasmLib = await this.loadTssWasm();
     if (this.keyType === KeyType.secp256k1) {
       const sig = await this.sign_ECDSA_secp256k1(data, hashed, secp256k1Precompute);
-      return Buffer.concat([sig.r, sig.s, Buffer.from([sig.v])]);
+      return Buffer.concat([new Uint8Array(sig.r), new Uint8Array(sig.s), new Uint8Array([sig.v])]);
     } else if (this.keyType === KeyType.ed25519) {
       return this.sign_ed25519(data, hashed);
     }
@@ -1244,7 +1244,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
         postboxKeyNodeIndexes: postboxKeyNodeIndexes || [],
         factorKey: factorKey?.toString("hex"),
         tssShareIndex: tssShareIndex as number,
-        tssPubKey: Buffer.from(tssPubKey).toString("hex"),
+        tssPubKey: tssPubKey.toString("hex"),
         signatures: this.signatures,
         userInfo,
       };
@@ -1521,7 +1521,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       clientXCoord,
       clientShareAdjustedHex,
       pubKeyHex,
-      data,
+      new Uint8Array(data),
       serverCoefficientsHex,
       this.socketTransports
     );

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1350,19 +1350,21 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   }
 
   private async deleteMetadataShareBackup(factorKey: BN): Promise<void> {
-    await this.tKey.addLocalMetadataTransitions({ input: [{ message: SHARE_DELETED, dateAdded: Date.now() }], privKey: [factorKey] });
-    if (!this.tkey?.manualSync) await this.tkey?.syncLocalMetadataTransitions();
+    await this.atomicSync(async () => {
+      await this.tKey.addLocalMetadataTransitions({ input: [{ message: SHARE_DELETED, dateAdded: Date.now() }], privKey: [factorKey] });
+    });
   }
 
   private async backupMetadataShare(factorKey: BN) {
     const metadataShare = await this.getMetadataShare();
 
-    // Set metadata for factor key backup
-    await this.tKey?.addLocalMetadataTransitions({
-      input: [metadataShare],
-      privKey: [factorKey],
+    await this.atomicSync(async () => {
+      // Set metadata for factor key backup
+      await this.tKey?.addLocalMetadataTransitions({
+        input: [metadataShare],
+        privKey: [factorKey],
+      });
     });
-    if (!this.tkey?.manualSync) await this.tkey?.syncLocalMetadataTransitions();
   }
 
   private async addFactorDescription(args: {

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -523,15 +523,17 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
   public async inputFactorKey(factorKey: BN): Promise<void> {
     this.checkReady();
     try {
-      // input tkey device share when required share > 0 ( or not reconstructed )
-      // assumption tkey shares will not changed
+      // always check for valid factor key
+      const factorKeyPrivate = factorKeyCurve.keyFromPrivate(factorKey.toBuffer());
+      const factorPubX = factorKeyPrivate.getPublic().getX().toString("hex").padStart(64, "0");
+      const factorEncExist = this.tkey.metadata.factorEncs?.[this.tkey.tssTag]?.[factorPubX];
+      if (!factorEncExist) {
+        throw CoreKitError.providedFactorKeyInvalid("Invalid FactorKey provided. Failed to input factor key.");
+      }
+
+      // input tkey device share when required share > 0 ( or tkey is not yet reconstructed )
+      // assumption tkey shares will never changed
       if (!this.tKey.secp256k1Key) {
-        const factorKeyPrivate = factorKeyCurve.keyFromPrivate(factorKey.toBuffer());
-        const factorPubX = factorKeyPrivate.getPublic().getX().toString("hex").padStart(64, "0");
-        const factorEncExist = this.tkey.metadata.factorEncs?.[this.tkey.tssTag]?.[factorPubX];
-        if (!factorEncExist) {
-          throw CoreKitError.providedFactorKeyInvalid("Invalid FactorKey provided. Failed to input factor key.");
-        }
         const factorKeyMetadata = await this.getFactorKeyMetadata(factorKey);
         await this.tKey.inputShareStoreSafe(factorKeyMetadata, true);
       }
@@ -897,19 +899,6 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
       // manual call syncLocalMetadataTransitions() required to sync local transitions to storage
       await this.tKey._syncShareMetadata();
       await this.tKey.syncLocalMetadataTransitions();
-
-      if (this.sessionManager && this.sessionId) {
-        const payload: SessionData = {
-          postBoxKey: this.state.postBoxKey,
-          postboxKeyNodeIndexes: this.state.postboxKeyNodeIndexes || [],
-          factorKey: this.state.factorKey?.toString("hex"),
-          tssShareIndex: this.state.tssShareIndex as number,
-          tssPubKey: this.state.tssPubKey?.toString("hex"),
-          signatures: this.signatures,
-          userInfo: this.state.userInfo,
-        };
-        this.sessionManager.updateSession(payload);
-      }
     } catch (error: unknown) {
       log.error("sync metadata error", error);
       throw error;
@@ -1180,7 +1169,22 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
     this.updateState({ tssShareIndex, tssPubKey, factorKey });
 
-    await this.createSession();
+
+    if (this.sessionManager && this.sessionId) {
+      const payload: SessionData = {
+        postBoxKey: this.state.postBoxKey,
+        postboxKeyNodeIndexes: this.state.postboxKeyNodeIndexes || [],
+        factorKey: this.state.factorKey?.toString("hex"),
+        tssShareIndex: this.state.tssShareIndex as number,
+        tssPubKey: this.state.tssPubKey?.toString("hex"),
+        signatures: this.signatures,
+        userInfo: this.state.userInfo,
+      };
+      this.sessionManager.updateSession(payload);
+    } else {
+      await this.createSession();
+    }
+
   }
 
   private checkReady() {

--- a/src/mpcCoreKit.ts
+++ b/src/mpcCoreKit.ts
@@ -1178,20 +1178,7 @@ export class Web3AuthMPCCoreKit implements ICoreKit {
 
     this.updateState({ tssShareIndex, tssPubKey, factorKey });
 
-    if (this.sessionManager && this.sessionId) {
-      const payload: SessionData = {
-        postBoxKey: this.state.postBoxKey,
-        postboxKeyNodeIndexes: this.state.postboxKeyNodeIndexes || [],
-        factorKey: this.state.factorKey?.toString("hex"),
-        tssShareIndex: this.state.tssShareIndex as number,
-        tssPubKey: this.state.tssPubKey?.toString("hex"),
-        signatures: this.signatures,
-        userInfo: this.state.userInfo,
-      };
-      this.sessionManager.updateSession(payload);
-    } else {
-      await this.createSession();
-    }
+    await this.createSession();
   }
 
   private checkReady() {

--- a/tests/ed25519.spec.ts
+++ b/tests/ed25519.spec.ts
@@ -6,7 +6,7 @@ import { UX_MODE_TYPE } from "@toruslabs/customauth";
 import { tssLib } from "@toruslabs/tss-frost-lib";
 import BN from "bn.js";
 
-import { AsyncStorage, COREKIT_STATUS, ed25519, MemoryStorage, WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE, Web3AuthMPCCoreKit } from "../src";
+import { AsyncStorage, COREKIT_STATUS, ed25519, MemoryStorage, TssShareType, WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE, Web3AuthMPCCoreKit } from "../src";
 import { bufferToElliptic, criticalResetAccount, mockLogin, mockLogin2 } from "./setup";
 
 type TestVariable = {
@@ -14,15 +14,19 @@ type TestVariable = {
   uxMode: UX_MODE_TYPE | "nodejs";
   manualSync?: boolean;
   email: string;
+  importedEmail: string
 };
 
-const defaultTestEmail = "testEmailForLoginEd25519";
+const defaultTestEmail = "testEmailForLoginEd25519-01";
+const importedEmail = "testEmailImportEd25519-01"
+
 const variable: TestVariable[] = [
-  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", email: defaultTestEmail },
+  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", email: defaultTestEmail, importedEmail },
   // { web3AuthNetwork: WEB3AUTH_NETWORK.MAINNET, uxMode: UX_MODE.REDIRECT, email: defaultTestEmail },
 
-  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", manualSync: true, email: defaultTestEmail },
+  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", manualSync: true, email: defaultTestEmail , importedEmail },
   // { web3AuthNetwork: WEB3AUTH_NETWORK.MAINNET, uxMode: UX_MODE.REDIRECT, manualSync: true, email: defaultTestEmail },
+
 ];
 
 const checkLogin = async (coreKitInstance: Web3AuthMPCCoreKit, accountIndex = 0) => {
@@ -39,7 +43,7 @@ const storageInstance = new MemoryStorage();
 
 variable.forEach((testVariable) => {
   const { web3AuthNetwork, uxMode, manualSync, email } = testVariable;
-  const newCoreKitInstance = () =>
+  const newCoreKitInstance = ( params: {disableSessionManager : boolean } = {disableSessionManager: true}) =>
     new Web3AuthMPCCoreKit({
       web3AuthClientId: "torus-key-test",
       web3AuthNetwork,
@@ -48,11 +52,12 @@ variable.forEach((testVariable) => {
       tssLib,
       storage: storageInstance,
       manualSync,
+      disableSessionManager: params.disableSessionManager
     });
 
-  async function resetAccount() {
+  async function resetAccount( resetEmail: string) {
     const resetInstance = newCoreKitInstance();
-    const { idToken, parsedToken } = await mockLogin(email);
+    const { idToken, parsedToken } = await mockLogin(resetEmail);
     await resetInstance.init({ handleRedirectResult: false, rehydrate: false });
     await resetInstance.loginWithJWT({
       verifier: "torus-test-health",
@@ -69,9 +74,11 @@ variable.forEach((testVariable) => {
   let checkTssShare: BN;
 
   test(`#Login Test with JWT + logout:  ${testNameSuffix}`, async (t) => {
-    await resetAccount();
+    await resetAccount(email);
+    await resetAccount(importedEmail);
+
     await t.test("#Login", async function () {
-      const coreKitInstance = newCoreKitInstance();
+      const coreKitInstance = newCoreKitInstance({disableSessionManager: false});
 
       // mocklogin
       const { idToken, parsedToken } = await mockLogin(email);
@@ -98,7 +105,7 @@ variable.forEach((testVariable) => {
     });
 
     await t.test("#relogin ", async function () {
-      const coreKitInstance = newCoreKitInstance();
+      const coreKitInstance = newCoreKitInstance({ disableSessionManager: false });
       // rehydrate
       await coreKitInstance.init({ handleRedirectResult: false });
       await checkLogin(coreKitInstance);
@@ -147,5 +154,39 @@ variable.forEach((testVariable) => {
       const valid = ed25519().verify(msgBuffer, signature, coreKitInstance.getPubKeyEd25519());
       assert(valid);
     });
+
+    await t.test("#able to export import", async function () {
+      const coreKitInstance = newCoreKitInstance();
+      await coreKitInstance.init({ handleRedirectResult: false, rehydrate: false });
+      const localToken = await mockLogin2(email);
+      await coreKitInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: email,
+        idToken: localToken.idToken,
+      });
+
+      await coreKitInstance.enableMFA({});
+      if (manualSync) {
+        await coreKitInstance.commitChanges();
+      }
+      const exportedSeed = await coreKitInstance._UNSAFE_exportTssEd25519Seed();
+
+      const coreKitInstance2 = newCoreKitInstance();
+      await coreKitInstance2.init({ handleRedirectResult: false, rehydrate: false });
+      const localToken2 = await mockLogin2(importedEmail);
+      await coreKitInstance2.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: importedEmail,
+        idToken: localToken2.idToken,
+        importTssKey: exportedSeed.toString("hex"),
+      });
+      
+      const exportedSeed2 = await coreKitInstance2._UNSAFE_exportTssEd25519Seed();
+
+      assert(exportedSeed.toString("hex") === (exportedSeed2.toString("hex")));
+    });
+
+
+
   });
 });

--- a/tests/ed25519.spec.ts
+++ b/tests/ed25519.spec.ts
@@ -171,6 +171,7 @@ variable.forEach((testVariable) => {
       }
       const exportedSeed = await coreKitInstance._UNSAFE_exportTssEd25519Seed();
 
+      // import tss key into mpc corekit
       const coreKitInstance2 = newCoreKitInstance();
       await coreKitInstance2.init({ handleRedirectResult: false, rehydrate: false });
       const localToken2 = await mockLogin2(importedEmail);
@@ -180,13 +181,13 @@ variable.forEach((testVariable) => {
         idToken: localToken2.idToken,
         importTssKey: exportedSeed.toString("hex"),
       });
+      if (manualSync) {
+        await coreKitInstance2.commitChanges();
+      }
       
       const exportedSeed2 = await coreKitInstance2._UNSAFE_exportTssEd25519Seed();
 
       assert(exportedSeed.toString("hex") === (exportedSeed2.toString("hex")));
     });
-
-
-
   });
 });

--- a/tests/ed25519.spec.ts
+++ b/tests/ed25519.spec.ts
@@ -6,7 +6,7 @@ import { UX_MODE_TYPE } from "@toruslabs/customauth";
 import { tssLib } from "@toruslabs/tss-frost-lib";
 import BN from "bn.js";
 
-import { AsyncStorage, COREKIT_STATUS, ed25519, MemoryStorage, TssShareType, WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE, Web3AuthMPCCoreKit } from "../src";
+import { AsyncStorage, COREKIT_STATUS, ed25519, MemoryStorage,  WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE, Web3AuthMPCCoreKit } from "../src";
 import { bufferToElliptic, criticalResetAccount, mockLogin, mockLogin2 } from "./setup";
 
 type TestVariable = {
@@ -64,7 +64,7 @@ variable.forEach((testVariable) => {
       verifierId: parsedToken.email,
       idToken,
     });
-    await criticalResetAccount(resetInstance);
+    await criticalResetAccount(resetInstance, manualSync);
     await new AsyncStorage(resetInstance._storageKey, storageInstance).resetStore();
   }
 

--- a/tests/factors.spec.ts
+++ b/tests/factors.spec.ts
@@ -1,14 +1,15 @@
 import assert from "node:assert";
 import test from "node:test";
 
-import { EllipticPoint, Point } from "@tkey/common-types";
+import { EllipticPoint, KeyType, Point, secp256k1 } from "@tkey/common-types";
 import { factorKeyCurve } from "@tkey/tss";
 import { tssLib as tssLibDKLS } from "@toruslabs/tss-dkls-lib";
 import { tssLib as tssLibFROST } from "@toruslabs/tss-frost-lib";
 import BN from "bn.js";
 
-import { COREKIT_STATUS, IAsyncStorage, IStorage, MemoryStorage, TssLibType, TssShareType, WEB3AUTH_NETWORK, Web3AuthMPCCoreKit } from "../src";
+import { AsyncStorage, COREKIT_STATUS, ed25519, IAsyncStorage, IStorage, MemoryStorage, sigToRSV, TssLibType, TssShareType, WEB3AUTH_NETWORK, Web3AuthMPCCoreKit } from "../src";
 import { AsyncMemoryStorage, bufferToElliptic, criticalResetAccount, mockLogin } from "./setup";
+import { keccak256 } from "@toruslabs/metadata-helpers";
 
 type FactorTestVariable = {
   manualSync?: boolean;
@@ -28,6 +29,26 @@ function getPubKeys(kit: Web3AuthMPCCoreKit, indices: number[]): EllipticPoint[]
   return pubKeys;
 }
 
+async function signSecp256k1Data( params : { coreKitInstance: Web3AuthMPCCoreKit, msg: string, }) {
+  const {coreKitInstance, msg } = params
+  const msgBuffer1 = Buffer.from(msg);
+  const msgHash = keccak256(msgBuffer1);
+
+  const signature = sigToRSV(await coreKitInstance.sign(msgHash, true));
+
+  const pubkey = secp256k1.recoverPubKey(msgHash, signature, signature.v) as EllipticPoint;
+  const publicKeyPoint = bufferToElliptic(coreKitInstance.getPubKey());
+  assert(pubkey.eq(publicKeyPoint));
+}
+
+async function signEd25519Data(params: { coreKitInstance: Web3AuthMPCCoreKit, msg: string }) {
+  const { coreKitInstance, msg } = params;
+  const msgBuffer = Buffer.from(msg)
+  const signature = ed25519().makeSignature((await coreKitInstance.sign(msgBuffer)).toString("hex"));
+  const valid = ed25519().verify(msgBuffer, signature, coreKitInstance.getPubKeyEd25519());
+  assert(valid);
+}
+
 export const FactorManipulationTest = async (testVariable: FactorTestVariable) => {
   const { email, tssLib } = testVariable;
   const newInstance = async () => {
@@ -39,6 +60,7 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
       tssLib: tssLib || tssLibDKLS,
       storage: testVariable.storage,
       manualSync: testVariable.manualSync,
+      disableSessionManager: true
     });
 
     const { idToken, parsedToken } = await mockLogin(email);
@@ -55,6 +77,7 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
     const resetInstance = await newInstance();
     await criticalResetAccount(resetInstance);
     await resetInstance.logout();
+    await new AsyncStorage(resetInstance._storageKey, testVariable.storage).resetStore();
   }
 
   await test(`#Factor manipulation - manualSync ${testVariable.manualSync} `, async function (t) {
@@ -163,6 +186,7 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
       // login with mfa factor
       await instance2.inputFactorKey(new BN(recoverFactor, "hex"));
       assert.strictEqual(instance2.status, COREKIT_STATUS.LOGGED_IN);
+
       await instance2.logout();
 
       // new instance
@@ -180,16 +204,24 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
 
       await instance3.inputFactorKey(new BN(browserFactor, "hex"));
       assert.strictEqual(instance3.status, COREKIT_STATUS.LOGGED_IN);
+
+      if ( tssLib && tssLib.keyType === KeyType.ed25519) {
+        await signEd25519Data({ coreKitInstance: instance3, msg: "hello world" });
+      } else {
+        await signSecp256k1Data({ coreKitInstance: instance3, msg: "hello world" });
+      }
+
     });
+
   });
 };
 
 const variable: FactorTestVariable[] = [
-  { manualSync: true, storage: new MemoryStorage(), email: "testmail1012" },
-  { manualSync: false, storage: new MemoryStorage(), email: "testmail1013" },
+  { manualSync: true, storage: new MemoryStorage(), email: "testmail1012-1" },
+  { manualSync: false, storage: new MemoryStorage(), email: "testmail1013-1" },
 
-  { manualSync: true, storage: new AsyncMemoryStorage(), email: "testmail1014" },
-  { manualSync: false, storage: new AsyncMemoryStorage(), email: "testmail1015" },
+  { manualSync: true, storage: new AsyncMemoryStorage(), email: "testmail1014-1" },
+  { manualSync: false, storage: new AsyncMemoryStorage(), email: "testmail1015-1" },
 
   { manualSync: true, storage: new MemoryStorage(), email: "testmail1012ed25519", tssLib: tssLibFROST },
 ];

--- a/tests/factors.spec.ts
+++ b/tests/factors.spec.ts
@@ -75,7 +75,7 @@ export const FactorManipulationTest = async (testVariable: FactorTestVariable) =
 
   async function beforeTest() {
     const resetInstance = await newInstance();
-    await criticalResetAccount(resetInstance);
+    await criticalResetAccount(resetInstance, testVariable.manualSync);
     await resetInstance.logout();
     await new AsyncStorage(resetInstance._storageKey, testVariable.storage).resetStore();
   }

--- a/tests/gating.spec.ts
+++ b/tests/gating.spec.ts
@@ -60,7 +60,7 @@ variable.forEach((testVariable) => {
   const testNameSuffix = testVariable.description;
   test(`#Gating test :  ${testNameSuffix}`, async (t) => {
     async function beforeTest() {
-      if (coreKitInstance.status === COREKIT_STATUS.INITIALIZED) await criticalResetAccount(coreKitInstance);
+      if (coreKitInstance.status === COREKIT_STATUS.INITIALIZED) await criticalResetAccount(coreKitInstance, manualSync);
     }
 
     t.after(async function () {

--- a/tests/importRecovery.spec.ts
+++ b/tests/importRecovery.spec.ts
@@ -4,8 +4,10 @@ import test from "node:test";
 import { tssLib as tssLibDKLS } from "@toruslabs/tss-dkls-lib";
 import { tssLib as tssLibFROST } from "@toruslabs/tss-frost-lib";
 
-import { AsyncStorage, MemoryStorage, TssLibType, TssShareType, WEB3AUTH_NETWORK } from "../src";
-import { bufferToElliptic, criticalResetAccount, newCoreKitLogInInstance } from "./setup";
+import {  MemoryStorage, sigToRSV, TssLibType, TssShareType, WEB3AUTH_NETWORK, Web3AuthMPCCoreKit } from "../src";
+import { bufferToElliptic, criticalResetAccount, mockLogin  } from "./setup";
+import { EllipticPoint, KeyType, secp256k1 } from "@tkey/common-types";
+import { keccak256 } from "@toruslabs/metadata-helpers";
 
 type ImportKeyTestVariable = {
   manualSync?: boolean;
@@ -13,25 +15,52 @@ type ImportKeyTestVariable = {
   importKeyEmail: string;
   tssLib: TssLibType;
 };
+async function signSecp256k1Data( params : { coreKitInstance: Web3AuthMPCCoreKit, msg: string, }) {
+  const {coreKitInstance, msg } = params
+  const msgBuffer1 = Buffer.from(msg);
+  const msgHash = keccak256(msgBuffer1);
 
+  const signature = sigToRSV(await coreKitInstance.sign(msgHash, true));
+
+  const pubkey = secp256k1.recoverPubKey(msgHash, signature, signature.v) as EllipticPoint;
+  const publicKeyPoint = bufferToElliptic(coreKitInstance.getPubKey());
+  assert(pubkey.eq(publicKeyPoint));
+}
 const storageInstance = new MemoryStorage();
 export const ImportTest = async (testVariable: ImportKeyTestVariable) => {
   async function newCoreKitInstance(email: string, importTssKey?: string) {
-    return newCoreKitLogInInstance({
-      network: WEB3AUTH_NETWORK.DEVNET,
-      manualSync: testVariable.manualSync,
-      email: email,
-      storageInstance,
-      tssLib: testVariable.tssLib,
-      importTssKey,
-    });
+      const instance = new Web3AuthMPCCoreKit({
+        web3AuthClientId: "torus-key-test",
+        web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET,
+        baseUrl: "http://localhost:3000",
+        uxMode: "nodejs",
+        tssLib: testVariable.tssLib,
+        storage: storageInstance,
+        manualSync: testVariable.manualSync,
+        disableSessionManager: true
+      });
+
+      const { idToken, parsedToken } = await mockLogin(email);
+      await instance.init({ handleRedirectResult: false, rehydrate: false });
+      await instance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken.email,
+        idToken,
+        importTssKey
+      });
+      return instance;
+    
   }
 
   async function resetAccount(email: string) {
     const kit = await newCoreKitInstance(email);
+    console.log('tss pub key', kit.state.tssPubKey)
     await criticalResetAccount(kit);
+    if (testVariable.manualSync) {
+      await kit.commitChanges();
+    }
     await kit.logout();
-    await new AsyncStorage(kit._storageKey, storageInstance).resetStore();
+    // await new AsyncStorage(kit._storageKey, storageInstance).resetStore();
   }
 
   test(`import recover tss key : ${testVariable.manualSync}`, async function (t) {
@@ -50,6 +79,9 @@ export const ImportTest = async (testVariable: ImportKeyTestVariable) => {
         shareType: TssShareType.DEVICE,
       });
 
+      if (testVariable.tssLib.keyType === KeyType.secp256k1) {
+        await signSecp256k1Data({ coreKitInstance, msg: "hello world" });
+      }
       const factorKeyRecovery = await coreKitInstance.createFactor({
         shareType: TssShareType.RECOVERY,
       });
@@ -62,8 +94,21 @@ export const ImportTest = async (testVariable: ImportKeyTestVariable) => {
       const exportedTssKey1 = await coreKitInstance._UNSAFE_exportTssKey();
       await coreKitInstance.logout();
 
+      const instance = new Web3AuthMPCCoreKit({
+        web3AuthClientId: "torus-key-test",
+        web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET,
+        baseUrl: "http://localhost:3000",
+        uxMode: "nodejs",
+        tssLib: testVariable.tssLib,
+        storage: storageInstance,
+        manualSync: testVariable.manualSync,
+        disableSessionManager: true
+      });
+
+      await instance.init({rehydrate: false, handleRedirectResult: false})
+      
       // Recover key from any two factors.
-      const recoveredTssKey = await coreKitInstance._UNSAFE_recoverTssKey([factorKeyDevice, factorKeyRecovery]);
+      const recoveredTssKey = await instance._UNSAFE_recoverTssKey([factorKeyDevice, factorKeyRecovery]);
       assert.strictEqual(recoveredTssKey, exportedTssKey1);
 
       // Initialize new instance and import existing key.
@@ -105,9 +150,9 @@ export const ImportTest = async (testVariable: ImportKeyTestVariable) => {
 };
 
 const variable: ImportKeyTestVariable[] = [
-  { manualSync: false, email: "emailexport", importKeyEmail: "emailimport", tssLib: tssLibDKLS },
-  { manualSync: true, email: "emailexport", importKeyEmail: "emailimport", tssLib: tssLibDKLS },
-  { manualSync: false, email: "emailexport_ed25519", importKeyEmail: "emailimport_ed25519", tssLib: tssLibFROST },
+  { manualSync: false, email: "emailexport-01", importKeyEmail: "emailimport-001", tssLib: tssLibDKLS },
+  { manualSync: true, email: "emailexport-01", importKeyEmail: "emailimport-001", tssLib: tssLibDKLS },
+  // { manualSync: false, email: "emailexport_ed25519", importKeyEmail: "emailimport_ed25519", tssLib: tssLibFROST },
 ];
 
 variable.forEach(async (testVariable) => {

--- a/tests/importRecovery.spec.ts
+++ b/tests/importRecovery.spec.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 import test from "node:test";
 
 import { tssLib as tssLibDKLS } from "@toruslabs/tss-dkls-lib";
-import { tssLib as tssLibFROST } from "@toruslabs/tss-frost-lib";
 
 import {  MemoryStorage, sigToRSV, TssLibType, TssShareType, WEB3AUTH_NETWORK, Web3AuthMPCCoreKit } from "../src";
 import { bufferToElliptic, criticalResetAccount, mockLogin  } from "./setup";
@@ -55,10 +54,7 @@ export const ImportTest = async (testVariable: ImportKeyTestVariable) => {
   async function resetAccount(email: string) {
     const kit = await newCoreKitInstance(email);
     console.log('tss pub key', kit.state.tssPubKey)
-    await criticalResetAccount(kit);
-    if (testVariable.manualSync) {
-      await kit.commitChanges();
-    }
+    await criticalResetAccount(kit, testVariable.manualSync);
     await kit.logout();
     // await new AsyncStorage(kit._storageKey, storageInstance).resetStore();
   }

--- a/tests/login-disableHashedFactorKey.spec.ts
+++ b/tests/login-disableHashedFactorKey.spec.ts
@@ -280,7 +280,7 @@ variable.forEach((testVariable) => {
       const deviceFactorKey3 = await coreKitInstance3.getDeviceFactor();
       await coreKitInstance3.inputFactorKey(new BN(deviceFactorKey3, "hex"));
 
-      coreKitInstance.setTssWalletIndex(0);
+      coreKitInstance3.setTssWalletIndex(0);
       const pubkey3index0 = bufferToElliptic(coreKitInstance3.getPubKey());
       coreKitInstance3.setTssWalletIndex(1);
       const pubkey3index1 = bufferToElliptic(coreKitInstance3.getPubKey());

--- a/tests/login-disableHashedFactorKey.spec.ts
+++ b/tests/login-disableHashedFactorKey.spec.ts
@@ -1,0 +1,295 @@
+import assert, { fail } from "node:assert";
+import test from "node:test";
+
+import { EllipticPoint } from "@tkey/common-types";
+import { UX_MODE_TYPE } from "@toruslabs/customauth";
+import { keccak256 } from "@toruslabs/metadata-helpers";
+import { tssLib } from "@toruslabs/tss-dkls-lib";
+import BN from "bn.js";
+import { ec as EC } from "elliptic";
+
+import { AsyncStorage, COREKIT_STATUS, MemoryStorage, sigToRSV, WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE, Web3AuthMPCCoreKit } from "../src";
+import { bufferToElliptic, criticalResetAccount, mockLogin, mockLogin2, stringGen } from "./setup";
+
+type TestVariable = {
+  web3AuthNetwork: WEB3AUTH_NETWORK_TYPE;
+  uxMode: UX_MODE_TYPE | "nodejs";
+  manualSync?: boolean;
+
+  email: string;
+};
+
+const defaultTestEmail = "testEmailForLogin-disableHashedFactorKey";
+const variable: TestVariable[] = [
+  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", email: defaultTestEmail },
+  // { web3AuthNetwork: WEB3AUTH_NETWORK.MAINNET, uxMode: UX_MODE.REDIRECT, email: defaultTestEmail },
+
+  { web3AuthNetwork: WEB3AUTH_NETWORK.DEVNET, uxMode: "nodejs", manualSync: true, email: defaultTestEmail },
+  // { web3AuthNetwork: WEB3AUTH_NETWORK.MAINNET, uxMode: UX_MODE.REDIRECT, manualSync: true, email: defaultTestEmail },
+];
+
+const checkLogin = async (coreKitInstance: Web3AuthMPCCoreKit, accountIndex = 0) => {
+  const keyDetails = coreKitInstance.getKeyDetails();
+  assert.strictEqual(coreKitInstance.status, COREKIT_STATUS.LOGGED_IN);
+  assert.strictEqual(keyDetails.requiredFactors, 0);
+  const factorkey = coreKitInstance.getCurrentFactorKey();
+  await coreKitInstance.tKey.getTSSShare(new BN(factorkey.factorKey, "hex"), {
+    accountIndex,
+  });
+};
+
+const storageInstance = new MemoryStorage();
+
+variable.forEach((testVariable) => {
+  const { web3AuthNetwork, uxMode, manualSync, email } = testVariable;
+  const newCoreKitInstance = () =>
+    new Web3AuthMPCCoreKit({
+      web3AuthClientId: "torus-key-test",
+      web3AuthNetwork,
+      baseUrl: "http://localhost:3000",
+      uxMode,
+      tssLib,
+      storage: storageInstance,
+      manualSync,
+      disableHashedFactorKey: true,
+      disableSessionManager: true
+    });
+
+  const testNameSuffix = JSON.stringify(testVariable);
+
+  let checkPubKey: EllipticPoint;
+  let checkTssShare: BN;
+
+  test(`#Login Test with JWT + logout :  ${testNameSuffix}`, async (t) => {
+    async function beforeTest() {
+      const resetInstance = new Web3AuthMPCCoreKit({
+        web3AuthClientId: "torus-key-test",
+        web3AuthNetwork,
+        baseUrl: "http://localhost:3000",
+        uxMode,
+        tssLib,
+        storage: storageInstance,
+        manualSync,
+      });
+      const { idToken, parsedToken } = await mockLogin(email);
+      await resetInstance.init({ handleRedirectResult: false, rehydrate: false });
+      await resetInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken.email,
+        idToken,
+      });
+      await criticalResetAccount(resetInstance);
+      await new AsyncStorage(resetInstance._storageKey, storageInstance).resetStore();
+    }
+
+    await beforeTest();
+    await t.test("#Login", async function () {
+      const coreKitInstance = newCoreKitInstance();
+
+      // mocklogin
+      const { idToken, parsedToken } = await mockLogin(email);
+      await coreKitInstance.init({ handleRedirectResult: false });
+      await coreKitInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken.email,
+        idToken,
+      });
+      // get key details
+      await checkLogin(coreKitInstance);
+
+      checkPubKey = bufferToElliptic(coreKitInstance.getPubKey());
+      const factorkey = coreKitInstance.getCurrentFactorKey();
+      const { tssShare } = await coreKitInstance.tKey.getTSSShare(new BN(factorkey.factorKey, "hex"), {
+        threshold: 0,
+      });
+      checkTssShare = tssShare;
+
+      if (manualSync) {
+        await coreKitInstance.commitChanges();
+      }
+      // check whether the public key and tss share is same as old sdks
+    });
+
+    await t.test("#relogin ", async function () {
+      const coreKitInstance = newCoreKitInstance();
+
+
+      // logout
+      await coreKitInstance.logout();
+
+      // rehydrate should fail
+      await coreKitInstance.init({
+        rehydrate: false,
+        handleRedirectResult: false,
+      });
+      assert.strictEqual(coreKitInstance.status, COREKIT_STATUS.INITIALIZED);
+      assert.throws(() => coreKitInstance.getCurrentFactorKey());
+
+      // relogin
+      const { idToken, parsedToken } = await mockLogin(email);
+      await coreKitInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken.email,
+        idToken,
+      });
+
+      const deviceFactorKey = await coreKitInstance.getDeviceFactor();
+      await coreKitInstance.inputFactorKey(new BN(deviceFactorKey, "hex"));
+      // get key details
+      await checkLogin(coreKitInstance);
+      const newPubKey = bufferToElliptic(coreKitInstance.getPubKey());
+      const factorkey = coreKitInstance.getCurrentFactorKey();
+      const { tssShare: newTssShare } = await coreKitInstance.tKey.getTSSShare(new BN(factorkey.factorKey, "hex"));
+      assert(checkPubKey.eq(newPubKey));
+      assert(checkTssShare.eq(newTssShare));
+    });
+
+    await t.test("#able to sign", async function () {
+      const coreKitInstance = newCoreKitInstance();
+      await coreKitInstance.init({ handleRedirectResult: false, rehydrate: false });
+      const localToken = await mockLogin2(email);
+      await coreKitInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: email,
+        idToken: localToken.idToken,
+      });
+
+      const deviceFactorKey = await coreKitInstance.getDeviceFactor();
+      await coreKitInstance.inputFactorKey(new BN(deviceFactorKey, "hex"));
+
+      const msg = "hello world";
+      const msgBuffer = Buffer.from(msg);
+      const msgHash = keccak256(msgBuffer);
+      const secp256k1 = new EC("secp256k1");
+
+      // Sign hash.
+      const signature = sigToRSV(await coreKitInstance.sign(msgHash, true));
+      const pubkey = secp256k1.recoverPubKey(msgHash, signature, signature.v) as EllipticPoint;
+      const publicKeyPoint = bufferToElliptic(coreKitInstance.getPubKey());
+      assert(pubkey.eq(publicKeyPoint));
+
+      // Sign full message.
+      const signature2 = sigToRSV(await coreKitInstance.sign(msgBuffer));
+      const pubkey2 = secp256k1.recoverPubKey(msgHash, signature2, signature2.v) as EllipticPoint;
+      assert(pubkey2.eq(publicKeyPoint));
+
+      // should fail to sign due to preSignValidation
+      {
+        coreKitInstance.setPreSigningHook(async ({ data }) => {
+          return {
+            success: false,
+            data: Buffer.from(data).toString("hex")
+          }
+        });
+
+        try {
+          await coreKitInstance.sign(msgHash, true);
+          fail("Should fail signing")
+        } catch (err) {
+          assert(err);
+        }
+      };
+
+      // should succeed to sign
+      {
+        coreKitInstance.setPreSigningHook(async ({ data }) => {
+          return {
+            success: true,
+            data: Buffer.from(data).toString("hex")
+          }
+        });
+        const signature = sigToRSV(await coreKitInstance.sign(msgHash, true));
+        const pubkey = secp256k1.recoverPubKey(msgHash, signature, signature.v) as EllipticPoint;
+        const publicKeyPoint = bufferToElliptic(coreKitInstance.getPubKey());
+        assert(pubkey.eq(publicKeyPoint));
+      };
+    });
+
+
+    await t.test("#Login and sign with different account/wallet index", async function () {
+      const vid = stringGen(10);
+      const coreKitInstance = newCoreKitInstance();
+      // mock login with random
+      const { idToken: idToken2, parsedToken: parsedToken2 } = await mockLogin(vid);
+      await coreKitInstance.init({ handleRedirectResult: false, rehydrate: false });
+      await coreKitInstance.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken2.email,
+        idToken: idToken2,
+      });
+
+      const deviceFactorKey = await coreKitInstance.getDeviceFactor();
+      await coreKitInstance.inputFactorKey(new BN(deviceFactorKey, "hex"));
+
+      const secp256k1 = new EC("secp256k1");
+      await coreKitInstance.setTssWalletIndex(0);
+
+      const msg = "hello world 1";
+      const msgBuffer = Buffer.from(msg);
+      const msgHash = keccak256(msgBuffer);
+      const signature1 = sigToRSV(await coreKitInstance.sign(msgHash, true));
+
+      const pubkeyIndex0 = secp256k1.recoverPubKey(msgHash, signature1, signature1.v);
+      const publicKeyPoint0 = bufferToElliptic(coreKitInstance.getPubKey());
+      assert(pubkeyIndex0.eq(publicKeyPoint0));
+
+      await coreKitInstance.setTssWalletIndex(1);
+
+      const msg1 = "hello world 2";
+      const msgBuffer1 = Buffer.from(msg1);
+      const msgHash1 = keccak256(msgBuffer1);
+
+      const signature2 = sigToRSV(await coreKitInstance.sign(msgHash1, true));
+
+      const pubkeyIndex1 = secp256k1.recoverPubKey(msgHash1, signature2, signature2.v) as EllipticPoint;
+      const publicKeyPoint1 = bufferToElliptic(coreKitInstance.getPubKey());
+      assert(pubkeyIndex1.eq(publicKeyPoint1));
+
+      await checkLogin(coreKitInstance, 1);
+
+      await coreKitInstance.setTssWalletIndex(2);
+
+      const msg2 = "hello world 3";
+      const msgBuffer2 = Buffer.from(msg2);
+      const msgHash2 = keccak256(msgBuffer2);
+      const signature3 = sigToRSV(await coreKitInstance.sign(msgHash2, true));
+
+      const pubkeyIndex2 = secp256k1.recoverPubKey(msgHash2, signature3, signature3.v) as EllipticPoint;
+      const publicKeyPoint2 = bufferToElliptic(coreKitInstance.getPubKey());
+      assert(pubkeyIndex2.eq(publicKeyPoint2));
+
+      await checkLogin(coreKitInstance, 2);
+
+      assert(!publicKeyPoint0.eq(publicKeyPoint1));
+      assert(!publicKeyPoint0.eq(publicKeyPoint2));
+      assert(!publicKeyPoint1.eq(publicKeyPoint2));
+
+      if (manualSync) {
+        await coreKitInstance.commitChanges();
+      }
+      const coreKitInstance3 = newCoreKitInstance();
+      // mock login with random
+      const { idToken: idToken3, parsedToken: parsedToken3 } = await mockLogin(vid);
+      await coreKitInstance3.init({ handleRedirectResult: false, rehydrate: false });
+      await coreKitInstance3.loginWithJWT({
+        verifier: "torus-test-health",
+        verifierId: parsedToken3.email,
+        idToken: idToken3,
+      });
+
+      const deviceFactorKey3 = await coreKitInstance3.getDeviceFactor();
+      await coreKitInstance3.inputFactorKey(new BN(deviceFactorKey3, "hex"));
+
+      coreKitInstance.setTssWalletIndex(0);
+      const pubkey3index0 = bufferToElliptic(coreKitInstance3.getPubKey());
+      coreKitInstance3.setTssWalletIndex(1);
+      const pubkey3index1 = bufferToElliptic(coreKitInstance3.getPubKey());
+      coreKitInstance3.setTssWalletIndex(2);
+      const pubkey3index2 = bufferToElliptic(coreKitInstance3.getPubKey());
+
+      assert(pubkeyIndex0.eq(pubkey3index0));
+      assert(pubkeyIndex1.eq(pubkey3index1));
+      assert(pubkeyIndex2.eq(pubkey3index2));
+    });
+  });
+});

--- a/tests/login-disableHashedFactorKey.spec.ts
+++ b/tests/login-disableHashedFactorKey.spec.ts
@@ -78,7 +78,7 @@ variable.forEach((testVariable) => {
         verifierId: parsedToken.email,
         idToken,
       });
-      await criticalResetAccount(resetInstance);
+      await criticalResetAccount(resetInstance, manualSync);
       await new AsyncStorage(resetInstance._storageKey, storageInstance).resetStore();
     }
 

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -76,7 +76,7 @@ variable.forEach((testVariable) => {
         verifierId: parsedToken.email,
         idToken,
       });
-      await criticalResetAccount(resetInstance);
+      await criticalResetAccount(resetInstance, manualSync);
       await new AsyncStorage(resetInstance._storageKey, storageInstance).resetStore();
     }
 

--- a/tests/securityQuestion.spec.ts
+++ b/tests/securityQuestion.spec.ts
@@ -29,7 +29,7 @@ export const TssSecurityQuestionsTest = async (newInstance: () => Promise<Web3Au
   test(`#Tss Security Question - ${testVariable.manualSync} `, async function (t) {
     async function beforeTest() {
       const coreKitInstance = await newInstance();
-      await criticalResetAccount(coreKitInstance);
+      await criticalResetAccount(coreKitInstance, testVariable.manualSync);
       await coreKitInstance.logout();
 
       await new AsyncStorage(coreKitInstance._storageKey, storageInstance).resetStore();

--- a/tests/securityQuestion.spec.ts
+++ b/tests/securityQuestion.spec.ts
@@ -123,7 +123,7 @@ const variable: TestVariable[] = [
   // { web3AuthNetwork: WEB3AUTH_NETWORK.MAINNET, uxMode: UX_MODE.REDIRECT, manualSync: true },
 ];
 
-const email = "testmail99";
+const email = "testmail99-1";
 
 variable.forEach(async (testVariable) => {
   const newCoreKitLogInInstance = async () => {

--- a/tests/sessionTime.spec.ts
+++ b/tests/sessionTime.spec.ts
@@ -76,7 +76,7 @@ variable.forEach(async (testVariable) => {
     });
 
     async function beforeTest() {
-      if (coreKitInstance.status === COREKIT_STATUS.INITIALIZED) await criticalResetAccount(coreKitInstance);
+      if (coreKitInstance.status === COREKIT_STATUS.INITIALIZED) await criticalResetAccount(coreKitInstance, manualSync);
     }
 
     t.after(async function () {
@@ -86,7 +86,7 @@ variable.forEach(async (testVariable) => {
 
     await beforeTest();
 
-    await t.test("`sessionTime` should be equal to `sessionTokenDuration` from #Login", async function (t) {
+    await t.test("`sessionTime` should be equal to `sessionTokenDuration` from #Login", async function () {
       // mocklogin
       const { idToken, parsedToken } = await mockLogin(email);
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -30,14 +30,10 @@ export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit):
     throw new Error("coreKitInstance is not set");
   }
 
-  if (coreKitInstance.tKey.secp256k1Key) {
-    await coreKitInstance.tKey.CRITICAL_deleteTkey();
-  } else {
-    await coreKitInstance.tKey.storageLayer.setMetadata({
-      privKey: new BN(coreKitInstance.state.postBoxKey!, "hex"),
-      input: { message: "KEY_NOT_FOUND" },
-    });
-  }
+  await coreKitInstance.tKey.storageLayer.setMetadata({
+    privKey: new BN(coreKitInstance.state.postBoxKey!, "hex"),
+    input: { message: "KEY_NOT_FOUND" },
+  });
 };
 
 const privateKey = "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCCD7oLrcKae+jVZPGx52Cb/lKhdKxpXjl9eGNa1MlY57A==";
@@ -114,7 +110,7 @@ export const newCoreKitLogInInstance = async ({
   });
 
   const { idToken, parsedToken } = login ? await login(email) : await mockLogin(email);
-  await instance.init();
+  await instance.init({ handleRedirectResult: false, rehydrate: false });
   await instance.loginWithJWT({
     verifier: "torus-test-health",
     verifierId: parsedToken.email,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -31,6 +31,7 @@ export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit, 
   }
 
   if (coreKitInstance.tKey.secp256k1Key) {
+    await coreKitInstance.commitChanges();
     await coreKitInstance.tKey.CRITICAL_deleteTkey();
   } else {
     await coreKitInstance.tKey.storageLayer.setMetadata({

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -30,10 +30,14 @@ export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit):
     throw new Error("coreKitInstance is not set");
   }
 
-  await coreKitInstance.tKey.storageLayer.setMetadata({
-    privKey: new BN(coreKitInstance.state.postBoxKey!, "hex"),
-    input: { message: "KEY_NOT_FOUND" },
-  });
+  if (coreKitInstance.tKey.secp256k1Key) {
+    await coreKitInstance.tKey.CRITICAL_deleteTkey();
+  } else {
+    await coreKitInstance.tKey.storageLayer.setMetadata({
+      privKey: new BN(coreKitInstance.state.postBoxKey!, "hex"),
+      input: { message: "KEY_NOT_FOUND" },
+    });
+  }
 };
 
 const privateKey = "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCCD7oLrcKae+jVZPGx52Cb/lKhdKxpXjl9eGNa1MlY57A==";

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -22,7 +22,7 @@ export const mockLogin2 = async (email: string) => {
   return { idToken, parsedToken };
 };
 
-export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit): Promise<void> => {
+export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit, manualSync: boolean): Promise<void> => {
   // This is a critical function that should only be used for testing purposes
   // Resetting your account means clearing all the metadata associated with it from the metadata server
   // The key details will be deleted from our server and you will not be able to recover your account
@@ -37,6 +37,9 @@ export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit):
       privKey: new BN(coreKitInstance.state.postBoxKey!, "hex"),
       input: { message: "KEY_NOT_FOUND" },
     });
+    if (manualSync) {
+      await coreKitInstance.commitChanges();
+    }
   }
 };
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -38,7 +38,7 @@ export const criticalResetAccount = async (coreKitInstance: Web3AuthMPCCoreKit, 
       input: { message: "KEY_NOT_FOUND" },
     });
     if (manualSync) {
-      await coreKitInstance.commitChanges();
+      await coreKitInstance.tKey.syncLocalMetadataTransitions();
     }
   }
 };

--- a/tests/sfaImport.spec.ts
+++ b/tests/sfaImport.spec.ts
@@ -28,7 +28,7 @@ export const ImportSFATest = async (testVariable: ImportKeyTestVariable) => {
 
   async function resetAccount(email: string) {
     const kit = await newCoreKitInstance(email);
-    await criticalResetAccount(kit);
+    await criticalResetAccount(kit, testVariable.manualSync);
     await kit.logout();
     await new AsyncStorage(kit._storageKey, storageInstance).resetStore();
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:


## Description
<!--- Describe your changes in detail -->

Fix disableHashedFactorkey feature
device factorkey is not set when disableHashedFactoryKey flag is set.
this is causing user lose the device factorkey during signup.
reinitialization - save deviceFactorkey on device if available 

Fix atomic sync for
backupMetadataShare
deleteMetadataShareBackup

Add checking for already log-in state in the beginning of loginWithJWT to prevent double login

Add checking for valid factor key during InputFactorKey via Metadata's FactorEncs instead of depend only on checking for metadata linking

update tests
update tests cases

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden login and factor handling, persist device factor for disableHashedFactorKey users, wrap metadata updates in atomic sync, and update/add tests (incl. new disableHashedFactorKey flows).
> 
> - **Core (src/mpcCoreKit.ts)**:
>   - Enforce no double-login by rejecting `loginWithOAuth/JWT` if already logged in/rehydrated.
>   - Validate `inputFactorKey` against `metadata.factorEncs` before accepting a factor; reconstruct and finalize accordingly.
>   - When `disableHashedFactorKey` is enabled:
>     - Persist device factor locally on signup and on session rehydration if missing.
>     - Remove hashed factor backup deletion during MFA enable flow.
>   - Wrap `backupMetadataShare` and `deleteMetadataShareBackup` in `atomicSync` for consistent metadata syncing.
>   - Improve metadata checks using `KEY_NOT_FOUND` and `SHARE_DELETED` constants; minor log message tweak on rehydration failure.
> - **Tests**:
>   - Add `login-disableHashedFactorKey.spec.ts` covering device factor persistence, signing, wallet indices, and pre-sign hooks.
>   - Broaden factor, login, gating, session time, ed25519, import/recovery, and SFA import tests:
>     - Pass `manualSync` to critical reset paths; standardize init flags; optionally disable session manager.
>     - Add signing helpers and assertions; adjust test emails; verify SFA key cleared post-import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef5be4cafe2840185f31041dbfb0120f3d041cc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->